### PR TITLE
Add YieldMax tickers fetch

### DIFF
--- a/app/extension.js
+++ b/app/extension.js
@@ -1,12 +1,42 @@
 const vscode = require('vscode');
 const si = require('systeminformation');
 
+/**
+ * Fetch the list of YieldMax ETF tickers from a free GitHub hosted CSV file.
+ * The dataset is maintained publicly and does not require any API key.
+ *
+ * @returns {Promise<string[]>} array of ticker symbols
+ */
+async function fetchYieldmaxTickers() {
+    const url = 'https://raw.githubusercontent.com/michaelpointek/yield_max_etf_analysis/main/reference.csv';
+    try {
+        const res = await fetch(url);
+        if (!res.ok) {
+            throw new Error(`Request failed: ${res.status}`);
+        }
+        const text = await res.text();
+        return text
+            .split('\n')
+            .slice(1)
+            .map(line => line.split(',')[0].trim())
+            .filter(Boolean);
+    } catch (err) {
+        console.error('Failed to fetch YieldMax tickers', err);
+        return [];
+    }
+}
+
 function activate(context) {
     let statusBarMemory = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 10000);
     statusBarMemory.command = undefined;
     statusBarMemory.color = 'yellow';
     context.subscriptions.push(statusBarMemory);
     statusBarMemory.show();
+
+    // Retrieve YieldMax tickers on activation and print them to the console
+    fetchYieldmaxTickers().then(tickers => {
+        console.log('YieldMax tickers:', tickers.join(', '));
+    });
 
     setInterval(async () => {
         let memData = await si.mem();
@@ -27,3 +57,4 @@ function activate(context) {
 }
 
 exports.activate = activate;
+exports.fetchYieldmaxTickers = fetchYieldmaxTickers;


### PR DESCRIPTION
## Summary
- add new `fetchYieldmaxTickers` helper
- use helper in `activate` to log available tickers

## Testing
- `npm test` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_684c8d14f068832883daccbba09aecfb